### PR TITLE
Fixed the issue of incorrect requests to update a panel

### DIFF
--- a/Source/NimbleCommander/NimbleCommander/States/FilePanels/PanelController.h
+++ b/Source/NimbleCommander/NimbleCommander/States/FilePanels/PanelController.h
@@ -7,6 +7,8 @@
 #include <Panel/PanelViewKeystrokeSink.h>
 #include <Panel/QuickSearch.h>
 #include <VFS/VFS.h>
+#include <fmt/format.h>
+#include <fmt/ranges.h>
 
 @class PanelController;
 @class PanelView;
@@ -240,3 +242,25 @@ using ContextMenuProvider = std::function<NSMenu *(std::vector<VFSListingItem> _
 @end
 
 #include "PanelController+DataAccess.h"
+
+template <>
+struct fmt::formatter<nc::panel::DirectoryChangeRequest> : fmt::formatter<std::string> {
+    constexpr auto parse(fmt::format_parse_context &ctx) { return ctx.begin(); }
+
+    template <typename FormatContext>
+    auto format(const nc::panel::DirectoryChangeRequest &_req, FormatContext &_ctx)
+    {
+
+        return fmt::format_to(
+            _ctx.out(),
+            "(RequestedDirectory='{}', VFS='{}', RequestFocusedEntry='{}', RequestSelectedEntries='{}', "
+            "PerformAsynchronous={}, LoadPreviousViewState={}, InitiatedByUser={})",
+            _req.RequestedDirectory,
+            _req.VFS->Tag(),
+            _req.RequestFocusedEntry,
+            _req.RequestSelectedEntries,
+            _req.PerformAsynchronous,
+            _req.LoadPreviousViewState,
+            _req.InitiatedByUser);
+    }
+};

--- a/Source/NimbleCommander/NimbleCommander/States/FilePanels/PanelController.mm
+++ b/Source/NimbleCommander/NimbleCommander/States/FilePanels/PanelController.mm
@@ -652,7 +652,7 @@ static void HeatUpConfigValues()
         auto dir_change_callback = [=] {
             dispatch_to_main_queue([=] {
                 Log::Debug("Got a notification about a directory change: '{}'", current_directory_path);
-                if( PanelController *pc = weakself ) {
+                if( PanelController *const pc = weakself ) {
                     if( pc.currentDirectoryPath == current_directory_path ) {
                         [pc refreshPanel];
                     }

--- a/Source/Panel/include/Panel/CursorBackup.h
+++ b/Source/Panel/include/Panel/CursorBackup.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2018-2021 Michael Kazakov. Subject to GNU General Public License version 3.
+// Copyright (C) 2018-2024 Michael Kazakov. Subject to GNU General Public License version 3.
 #pragma once
 
 #include <Panel/PanelDataExternalEntryKey.h>
@@ -20,8 +20,7 @@ private:
     int FindRestoredCursorPosition() const noexcept;
 
     const data::Model &m_Data;
-    std::string m_OldCursorName; // reduntant? it's already in m_OldEntrySortKeys
-    data::ExternalEntryKey m_OldEntrySortKeys;
+    data::ExternalEntryKey m_Keys;
 };
 
 } // namespace nc::panel

--- a/Source/Panel/include/Panel/CursorBackup.h
+++ b/Source/Panel/include/Panel/CursorBackup.h
@@ -20,7 +20,7 @@ private:
     int FindRestoredCursorPosition() const noexcept;
 
     const data::Model &m_Data;
-    std::string m_OldCursorName;
+    std::string m_OldCursorName; // reduntant? it's already in m_OldEntrySortKeys
     data::ExternalEntryKey m_OldEntrySortKeys;
 };
 

--- a/Source/Panel/include/Panel/PanelDataExternalEntryKey.h
+++ b/Source/Panel/include/Panel/PanelDataExternalEntryKey.h
@@ -1,27 +1,52 @@
-// Copyright (C) 2017-2021 Michael Kazakov. Subject to GNU General Public License version 3.
+// Copyright (C) 2017-2024 Michael Kazakov. Subject to GNU General Public License version 3.
 #pragma once
 
 #include <VFS/VFS.h>
 #include <Base/CFPtr.h>
+#include <fmt/format.h>
 
 namespace nc::panel::data {
 
 struct ItemVolatileData;
 
 struct ExternalEntryKey {
-    ExternalEntryKey();
+    ExternalEntryKey() noexcept;
     ExternalEntryKey(const VFSListingItem &_item, const ItemVolatileData &_item_vd);
 
     std::string name;
     std::string extension;
     nc::base::CFPtr<CFStringRef> display_name;
-    uint64_t size;
-    time_t mtime;
-    time_t btime;
-    time_t atime;
+    uint64_t size = 0;
+    time_t mtime = 0;
+    time_t btime = 0;
+    time_t atime = 0;
     time_t add_time; // -1 means absent
-    bool is_dir;
+    bool is_dir = false;
     bool is_valid() const noexcept;
 };
 
 } // namespace nc::panel::data
+
+template <>
+struct fmt::formatter<nc::panel::data::ExternalEntryKey> : fmt::formatter<std::string> {
+    constexpr auto parse(fmt::format_parse_context &ctx) { return ctx.begin(); }
+
+    template <typename FormatContext>
+    auto format(const nc::panel::data::ExternalEntryKey &_key, FormatContext &_ctx)
+    {
+
+        return fmt::format_to(_ctx.out(),
+                              "(name='{}', extension='{}', display='{}', size={}, directory={}, mtime={}, btime={}, "
+                              "atime={}, addtime={})",
+                              _key.name,
+                              _key.extension,
+                              _key.display_name ? nc::base::CFStringGetUTF8StdString(_key.display_name.get())
+                                                : std::string{},
+                              _key.size,
+                              _key.is_dir,
+                              _key.mtime,
+                              _key.btime,
+                              _key.atime,
+                              _key.add_time);
+    }
+};

--- a/Source/Panel/source/CursorBackup.mm
+++ b/Source/Panel/source/CursorBackup.mm
@@ -14,11 +14,13 @@ CursorBackup::CursorBackup(int _current_cursor_pos, const data::Model &_data) no
         assert(item);
         m_OldCursorName = item.Filename();
         m_OldEntrySortKeys = _data.EntrySortKeysAtSortPosition(_current_cursor_pos);
+        Log::Trace("Saved sort keys: {}", m_OldEntrySortKeys);
     }
 }
 
 int CursorBackup::RestoredCursorPosition() const noexcept
 {
+    Log::Trace("Restoring cursor position from the keys {}", m_OldEntrySortKeys);
     const int restored_pos = FindRestoredCursorPosition();
     Log::Trace("Restored cursor position: {}", restored_pos);
     return restored_pos;

--- a/Source/Panel/source/CursorBackup.mm
+++ b/Source/Panel/source/CursorBackup.mm
@@ -1,4 +1,4 @@
-// Copyright (C) 2018-2021 Michael Kazakov. Subject to GNU General Public License version 3.
+// Copyright (C) 2018-2024 Michael Kazakov. Subject to GNU General Public License version 3.
 #include "CursorBackup.h"
 #include <Panel/PanelData.h>
 #include <Panel/Log.h>
@@ -10,17 +10,14 @@ CursorBackup::CursorBackup(int _current_cursor_pos, const data::Model &_data) no
     Log::Trace("Saving cursor position: {}", _current_cursor_pos);
     if( _current_cursor_pos >= 0 ) {
         assert(_current_cursor_pos < _data.SortedEntriesCount());
-        auto item = _data.EntryAtSortPosition(_current_cursor_pos);
-        assert(item);
-        m_OldCursorName = item.Filename();
-        m_OldEntrySortKeys = _data.EntrySortKeysAtSortPosition(_current_cursor_pos);
-        Log::Trace("Saved sort keys: {}", m_OldEntrySortKeys);
+        m_Keys = _data.EntrySortKeysAtSortPosition(_current_cursor_pos);
+        Log::Trace("Saved sort keys: {}", m_Keys);
     }
 }
 
 int CursorBackup::RestoredCursorPosition() const noexcept
 {
-    Log::Trace("Restoring cursor position from the keys {}", m_OldEntrySortKeys);
+    Log::Trace("Restoring cursor position from the keys {}", m_Keys);
     const int restored_pos = FindRestoredCursorPosition();
     Log::Trace("Restored cursor position: {}", restored_pos);
     return restored_pos;
@@ -28,11 +25,11 @@ int CursorBackup::RestoredCursorPosition() const noexcept
 
 int CursorBackup::FindRestoredCursorPosition() const noexcept
 {
-    if( m_OldCursorName.empty() ) {
+    if( m_Keys.name.empty() ) {
         return m_Data.SortedEntriesCount() > 0 ? 0 : -1;
     }
 
-    const auto new_cursor_raw_pos = m_Data.RawIndexForName(m_OldCursorName.c_str());
+    const auto new_cursor_raw_pos = m_Data.RawIndexForName(m_Keys.name);
     if( new_cursor_raw_pos >= 0 ) {
         const auto new_cursor_sort_pos = m_Data.SortedIndexForRawIndex(new_cursor_raw_pos);
         if( new_cursor_sort_pos >= 0 )
@@ -41,7 +38,7 @@ int CursorBackup::FindRestoredCursorPosition() const noexcept
             return m_Data.SortedDirectoryEntries().empty() ? -1 : 0;
     }
     else {
-        const auto lower_bound_ind = m_Data.SortLowerBoundForEntrySortKeys(m_OldEntrySortKeys);
+        const auto lower_bound_ind = m_Data.SortLowerBoundForEntrySortKeys(m_Keys);
         if( lower_bound_ind >= 0 ) {
             return lower_bound_ind;
         }

--- a/Source/Panel/source/PanelDataExternalEntryKey.cpp
+++ b/Source/Panel/source/PanelDataExternalEntryKey.cpp
@@ -1,13 +1,10 @@
-// Copyright (C) 2017-2021 Michael Kazakov. Subject to GNU General Public License version 3.
+// Copyright (C) 2017-2024 Michael Kazakov. Subject to GNU General Public License version 3.
 #include "PanelDataExternalEntryKey.h"
 #include "PanelDataItemVolatileData.h"
 
 namespace nc::panel::data {
 
-ExternalEntryKey::ExternalEntryKey()
-    : name{""}, extension{""}, display_name{}, size{0}, mtime{0}, btime{0}, atime{0}, add_time{-1}, is_dir{false}
-{
-}
+ExternalEntryKey::ExternalEntryKey() noexcept = default;
 
 ExternalEntryKey::ExternalEntryKey(const VFSListingItem &_item, const ItemVolatileData &_item_vd) : ExternalEntryKey()
 {


### PR DESCRIPTION
- Added more checks to discard stopped and stale refresh requests.
- Limited the length of the reload queue to two jobs.
- Added more logging points.
- Fixed #357