### PR TITLE
On macOS12 also use xpc_connection_set_peer_code_signing_requirement(…

### DIFF
--- a/Source/RoutedIO/source/PrivilegedIOHelper.cpp
+++ b/Source/RoutedIO/source/PrivilegedIOHelper.cpp
@@ -662,6 +662,16 @@ static void XPC_Connection_Handler(xpc_connection_t _connection)
         return;
     }
 
+    if( __builtin_available(macOS 12.0, *) ) {
+        // On MacOS12+ we also ask the OS itself to enforce the code signing requirement per connection
+        const int rc = xpc_connection_set_peer_code_signing_requirement(_connection, g_SignatureRequirement);
+        if( rc != 0 ) {
+            syslog_warning("xpc_connection_set_peer_code_signing_requirement() failed, dropping connection.");
+            xpc_connection_cancel(_connection);
+            return;
+        }
+    }
+
     ConnectionContext *cc = new ConnectionContext;
     xpc_connection_set_context(_connection, cc);
     xpc_connection_set_finalizer_f(_connection, [](void *_value) {


### PR DESCRIPTION
…) to enforce checking of code signing requirements per XPC connection to the priviledged helper