### PR TITLE
Improve builtin shell directory switching for paths with square brackets

### DIFF
--- a/Source/Term/source/Task.cpp
+++ b/Source/Term/source/Task.cpp
@@ -180,7 +180,7 @@ unsigned Task::ReadInputAsMuchAsAvailable(int _fd, void *_buf, unsigned _buf_sz,
 
 std::string Task::EscapeShellFeed(const std::string &_feed)
 {
-    static const char to_esc[] = {'|', '&', ';', '<', '>', '(', ')', '$', '\'', '\\', '\"', '`', ' ', '\t', '!'};
+    static const char to_esc[] = {'|', '&', ';', '<', '>', '(', ')', '$', '\'', '\\', '\"', '`', ' ', '\t', '!', '[', ']'};
     std::string result;
     result.reserve(_feed.length());
     for( auto c : _feed ) {

--- a/Source/Term/source/Task.cpp
+++ b/Source/Term/source/Task.cpp
@@ -180,7 +180,8 @@ unsigned Task::ReadInputAsMuchAsAvailable(int _fd, void *_buf, unsigned _buf_sz,
 
 std::string Task::EscapeShellFeed(const std::string &_feed)
 {
-    static const char to_esc[] = {'|', '&', ';', '<', '>', '(', ')', '$', '\'', '\\', '\"', '`', ' ', '\t', '!', '[', ']'};
+    static const char to_esc[] = {
+        '|', '&', ';', '<', '>', '(', ')', '$', '\'', '\\', '\"', '`', ' ', '\t', '!', '[', ']'};
     std::string result;
     result.reserve(_feed.length());
     for( auto c : _feed ) {

--- a/Source/Term/tests/ShellTask_IT.cpp
+++ b/Source/Term/tests/ShellTask_IT.cpp
@@ -1013,3 +1013,37 @@ TEST_CASE(PREFIX "Doesn't allow double-launch")
     REQUIRE(shell.Launch(CommonPaths::AppTemporaryDirectory()));
     CHECK_THROWS_AS(shell.Launch(CommonPaths::AppTemporaryDirectory()), std::logic_error);
 }
+
+TEST_CASE(PREFIX "ChDir respects literal square-bracketed directory despite glob expansion")
+{
+    const TempTestDir dir;
+    ShellTask shell;
+    QueuedAtomicHolder<std::pair<std::filesystem::path, bool>> cwd;
+    shell.SetOnPwdPrompt([&](const char *_cwd, bool _changed) {
+        cwd.store({_cwd, _changed});
+    });
+
+    const auto bracketedDir = dir.directory / "a[bc]d" / "";
+    std::filesystem::create_directory(bracketedDir);
+
+    SECTION("/bin/bash") {
+        shell.SetShellPath("/bin/bash");
+    }
+    SECTION("/bin/zsh") {
+        shell.SetShellPath("/bin/zsh");
+    }
+    SECTION("/bin/tcsh") {
+        shell.SetShellPath("/bin/tcsh");
+    }
+    SECTION("/bin/csh") {
+        shell.SetShellPath("/bin/csh");
+    }
+
+    REQUIRE(shell.Launch(dir.directory));
+    REQUIRE(cwd.wait_to_become(5s, {dir.directory, false}));
+    REQUIRE(shell.CWD() == dir.directory.generic_string());
+
+    shell.ChDir(bracketedDir);
+    REQUIRE(cwd.wait_to_become(5s, {bracketedDir, true}));
+    CHECK(shell.CWD() == bracketedDir.generic_string());
+}

--- a/Source/Term/tests/ShellTask_IT.cpp
+++ b/Source/Term/tests/ShellTask_IT.cpp
@@ -1019,23 +1019,25 @@ TEST_CASE(PREFIX "ChDir respects literal square-bracketed directory despite glob
     const TempTestDir dir;
     ShellTask shell;
     QueuedAtomicHolder<std::pair<std::filesystem::path, bool>> cwd;
-    shell.SetOnPwdPrompt([&](const char *_cwd, bool _changed) {
-        cwd.store({_cwd, _changed});
-    });
+    shell.SetOnPwdPrompt([&](const char *_cwd, bool _changed) { cwd.store({_cwd, _changed}); });
 
     const auto bracketedDir = dir.directory / "a[bc]d" / "";
     std::filesystem::create_directory(bracketedDir);
 
-    SECTION("/bin/bash") {
+    SECTION("/bin/bash")
+    {
         shell.SetShellPath("/bin/bash");
     }
-    SECTION("/bin/zsh") {
+    SECTION("/bin/zsh")
+    {
         shell.SetShellPath("/bin/zsh");
     }
-    SECTION("/bin/tcsh") {
+    SECTION("/bin/tcsh")
+    {
         shell.SetShellPath("/bin/tcsh");
     }
-    SECTION("/bin/csh") {
+    SECTION("/bin/csh")
+    {
         shell.SetShellPath("/bin/csh");
     }
 


### PR DESCRIPTION
Square brackets (`[` and `]`) are valid characters in macOS filenames but have a special role in shell globbing. 
This change adds these characters to the escape list in EscapeShellFeed, 
ensuring that the builtin shell correctly changes directories even when paths contain square brackets.

Other characters (e.g., *, ?, {, }, ~, #, %) are not addressed in this change as they have not resulted in directory switching issues in normal usage.