### PR TITLE
--new-window command to open new window without new instance from command line

### DIFF
--- a/Source/NimbleCommander/NimbleCommander/Bootstrap/CLI.cpp
+++ b/Source/NimbleCommander/NimbleCommander/Bootstrap/CLI.cpp
@@ -4,7 +4,16 @@
 #include <string_view>
 #include <iostream>
 #include <cstdlib>
+#include <unistd.h>
+#include <sys/types.h>
+#include <spawn.h>
+#include <fcntl.h>
+#include <CoreFoundation/CoreFoundation.h>
+#include <mach-o/dyld.h> // For _NSGetExecutablePath
 #include <RoutedIO/RoutedIO.h>
+
+// Declaration for environ which is defined in unistd.h on many systems but not on macOS
+extern char **environ;
 
 namespace nc::bootstrap {
 
@@ -23,6 +32,8 @@ static bool g_ShouldOpenNewWindow = false;
 void ProcessCLIUsage(int argc, char *argv[])
 {
     const std::vector<std::string_view> args(argv, argv + argc);
+    bool isTerminalLaunch = isatty(STDIN_FILENO);
+    
     for( auto arg : args ) {
         if( arg == "--help" ) {
             std::cout << g_Message << std::flush;
@@ -38,10 +49,87 @@ void ProcessCLIUsage(int argc, char *argv[])
         }
         if( arg == "--new-window" ) {
             g_ShouldOpenNewWindow = true;
+            // If launched from terminal, detach the process so it doesn't block the terminal
+            if (isTerminalLaunch) {
+                // Get the current executable path
+                char exePath[PATH_MAX];
+                uint32_t size = sizeof(exePath);
+                if (_NSGetExecutablePath(exePath, &size) == 0) {
+                    int devnull = -1;
+                    posix_spawn_file_actions_t fileActions;
+                    posix_spawnattr_t attr;
+                    bool init_success = false;
+                    
+                    // Initialize file actions
+                    if (posix_spawn_file_actions_init(&fileActions) == 0) {
+                        // Open /dev/null before setting up redirections
+                        devnull = open("/dev/null", O_RDWR);
+                        if (devnull >= 0) {
+                            // Set up redirections in the correct order
+                            // First redirect to /dev/null
+                            if (posix_spawn_file_actions_adddup2(&fileActions, devnull, STDIN_FILENO) == 0 &&
+                                posix_spawn_file_actions_adddup2(&fileActions, devnull, STDOUT_FILENO) == 0 &&
+                                posix_spawn_file_actions_adddup2(&fileActions, devnull, STDERR_FILENO) == 0) {
+                                
+                                // Close the original devnull fd in the child after redirection
+                                if (posix_spawn_file_actions_addclose(&fileActions, devnull) == 0) {
+                                    // Set up spawn attributes for new session
+                                    if (posix_spawnattr_init(&attr) == 0) {
+                                        // Create a new session and process group
+                                        short flags = POSIX_SPAWN_SETSID;
+                                        if (posix_spawnattr_setflags(&attr, flags) == 0) {
+                                            init_success = true;
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    
+                    if (init_success) {
+                        // Prepare arguments for the new process
+                        std::vector<char*> newArgv(argc + 1);
+                        for (int i = 0; i < argc; ++i) {
+                            newArgv[i] = argv[i];
+                        }
+                        newArgv[argc] = nullptr;
+                        
+                        // Spawn the detached process
+                        pid_t childPid;
+                        int spawn_result = posix_spawn(&childPid, exePath, &fileActions, &attr, newArgv.data(), environ);
+                        
+                        if (spawn_result == 0) {
+                            // Success - parent exits immediately
+                            if (devnull >= 0) {
+                                close(devnull); // Close devnull in the parent
+                            }
+                            
+                            // Clean up in parent before exit
+                            posix_spawnattr_destroy(&attr);
+                            posix_spawn_file_actions_destroy(&fileActions);
+                            
+                            _exit(0); // Exit without running destructors or atexit handlers
+                        } else {
+                            std::cerr << "Failed to spawn detached process: " << strerror(spawn_result) << std::endl;
+                        }
+                    } else {
+                        std::cerr << "Failed to initialize process detachment" << std::endl;
+                    }
+                    
+                    // Clean up if we didn't exit or if initialization failed
+                    if (devnull >= 0) {
+                        close(devnull);
+                    }
+                    
+                    if (init_success) {
+                        posix_spawnattr_destroy(&attr);
+                        posix_spawn_file_actions_destroy(&fileActions);
+                    }
+                }
+            }
         }
     }
 }
-
 bool ShouldOpenNewWindowFromCLI() {
     return g_ShouldOpenNewWindow;
 }

--- a/Source/NimbleCommander/NimbleCommander/Bootstrap/CLI.cpp
+++ b/Source/NimbleCommander/NimbleCommander/Bootstrap/CLI.cpp
@@ -15,7 +15,10 @@ static const auto g_Message = "Command-line options:                            
                               "Command-line commands:                                                         \n"
                               "--help                          Prints this message.                           \n"
                               "--install-privileged-helper     Installs the Admin Mode helper.                \n"
-                              "--uninstall-privileged-helper   Stops and uninstalls the Admin Mode helper.    \n";
+                              "--uninstall-privileged-helper   Stops and uninstalls the Admin Mode helper.    \n"
+                              "--new-window                   Opens a new window in the current instance.    \n";
+
+static bool g_ShouldOpenNewWindow = false;
 
 void ProcessCLIUsage(int argc, char *argv[])
 {
@@ -33,7 +36,14 @@ void ProcessCLIUsage(int argc, char *argv[])
             nc::routedio::RoutedIO::UninstallViaRootCLI();
             std::exit(0);
         }
+        if( arg == "--new-window" ) {
+            g_ShouldOpenNewWindow = true;
+        }
     }
+}
+
+bool ShouldOpenNewWindowFromCLI() {
+    return g_ShouldOpenNewWindow;
 }
 
 } // namespace nc::bootstrap

--- a/Source/NimbleCommander/NimbleCommander/Bootstrap/CLI.h
+++ b/Source/NimbleCommander/NimbleCommander/Bootstrap/CLI.h
@@ -4,5 +4,6 @@
 namespace nc::bootstrap {
 
 void ProcessCLIUsage(int argc, char *argv[]);
+bool ShouldOpenNewWindowFromCLI();
 
 }


### PR DESCRIPTION
In response to #83 #255, launching from command line, I needed to create new windows via the command line to use with skhd.

```open -a Nimble\ Commander``` will not create new windows if there is currently an open instance, meanwhile
```open -a -n Nimble\ Commander``` will open a new instance of the app, which is ugly behavior.

PR amends CLI.cpp & AppDelegate.mm, adding `ShouldOpenNewWindowFromCLI()` to add the ```--new-window``` flag so new windows may be launched with ```/Applications/Nimble\ Commander/Contents/MacOS/Nimble\ Commander --new-window``` without having to resort to some osascript implementation, which is slow.