### PR TITLE
Accept quoted paths in Go To Folder

### DIFF
--- a/Source/Utility/source/PathManip.cpp
+++ b/Source/Utility/source/PathManip.cpp
@@ -85,6 +85,12 @@ std::filesystem::path PathManip::Expand(std::string_view _path, std::string_view
     if( _cwd.empty() )
         _cwd = "/";
 
+    if( _path.size() >= 2 ) {
+        const char first = _path.front();
+        if( (first == '\'' || first == '"') && _path.back() == first )
+            _path = _path.substr(1, _path.size() - 2);
+    }
+
     if( _path.empty() ) {
         // empty path - return empty
         return {};

--- a/Source/Utility/source/PathManip.cpp
+++ b/Source/Utility/source/PathManip.cpp
@@ -87,7 +87,8 @@ std::filesystem::path PathManip::Expand(std::string_view _path, std::string_view
 
     if( _path.size() >= 2 ) {
         const char first = _path.front();
-        if( (first == '\'' || first == '"') && _path.back() == first )
+        const char second = _path[1];
+        if( (first == '\'' || first == '"') && _path.back() == first && (second == '/' || second == '~') )
             _path = _path.substr(1, _path.size() - 2);
     }
 

--- a/Source/Utility/source/PathManip.cpp
+++ b/Source/Utility/source/PathManip.cpp
@@ -88,7 +88,7 @@ std::filesystem::path PathManip::Expand(std::string_view _path, std::string_view
     if( _path.size() >= 2 ) {
         const char first = _path.front();
         const char second = _path[1];
-        if( (first == '\'' || first == '"') && _path.back() == first && (second == '/' || second == '~') )
+        if( (first == '\'' || first == '"') && (second == '/' || second == '~') && _path.back() == first )
             _path = _path.substr(1, _path.size() - 2);
     }
 

--- a/Source/Utility/tests/PathManip_UT.cpp
+++ b/Source/Utility/tests/PathManip_UT.cpp
@@ -179,6 +179,11 @@ TEST_CASE(PREFIX "Expand")
         {.path = "..", .home = "", .cwd = "/a/b/", .expected = "/a/"},
         {.path = "../", .home = "", .cwd = "/a/b/", .expected = "/a/"},
         {.path = "../c", .home = "", .cwd = "/a/b/", .expected = "/a/c"},
+        // quoted paths
+        {.path = "'/a/b'", .home = "", .cwd = "", .expected = "/a/b"},
+        {.path = "\"/a/b\"", .home = "", .cwd = "", .expected = "/a/b"},
+        {.path = "'/a/b", .home = "", .cwd = "", .expected = "/'/a/b"},
+        {.path = "\"/a/b", .home = "", .cwd = "", .expected = "/\"/a/b"},
     };
     for( auto &tc : tcs ) {
         INFO(tc.path);

--- a/Source/Utility/tests/PathManip_UT.cpp
+++ b/Source/Utility/tests/PathManip_UT.cpp
@@ -180,13 +180,13 @@ TEST_CASE(PREFIX "Expand")
         {.path = "../", .home = "", .cwd = "/a/b/", .expected = "/a/"},
         {.path = "../c", .home = "", .cwd = "/a/b/", .expected = "/a/c"},
         // strip surrounding quotes for absolute or home-relative paths
-        {.path = "'/a/b'", .home = "", .cwd = "", .expected = "/a/b"}, // single-quoted abs path: strip
-        {.path = "\"/a/b\"", .home = "", .cwd = "", .expected = "/a/b"}, // double-quoted abs path: strip
-        {.path = "'~/a/b'", .home = "/h", .cwd = "", .expected = "/h/a/b"}, // single-quoted home path: strip
+        {.path = "'/a/b'", .home = "", .cwd = "", .expected = "/a/b"},        // single-quoted abs path: strip
+        {.path = "\"/a/b\"", .home = "", .cwd = "", .expected = "/a/b"},      // double-quoted abs path: strip
+        {.path = "'~/a/b'", .home = "/h", .cwd = "", .expected = "/h/a/b"},   // single-quoted home path: strip
         {.path = "\"~/a/b\"", .home = "/h", .cwd = "", .expected = "/h/a/b"}, // double-quoted home path: strip
-        {.path = "'a'", .home = "", .cwd = "/c", .expected = "/c/'a'"}, // surrounded with single quotes: keep
-        {.path = "\"a\"", .home = "", .cwd = "/c", .expected = "/c/\"a\""}, // surrounded with double quotes: keep
-        {.path = "'/a/b", .home = "", .cwd = "/c", .expected = "/c/'/a/b"}, // mismatched single quote: keep
+        {.path = "'a'", .home = "", .cwd = "/c", .expected = "/c/'a'"},       // surrounded with single quotes: keep
+        {.path = "\"a\"", .home = "", .cwd = "/c", .expected = "/c/\"a\""},   // surrounded with double quotes: keep
+        {.path = "'/a/b", .home = "", .cwd = "/c", .expected = "/c/'/a/b"},   // mismatched single quote: keep
         {.path = "\"/a/b", .home = "", .cwd = "/c", .expected = "/c/\"/a/b"}, // mismatched double quote: keep
     };
     for( auto &tc : tcs ) {

--- a/Source/Utility/tests/PathManip_UT.cpp
+++ b/Source/Utility/tests/PathManip_UT.cpp
@@ -179,11 +179,15 @@ TEST_CASE(PREFIX "Expand")
         {.path = "..", .home = "", .cwd = "/a/b/", .expected = "/a/"},
         {.path = "../", .home = "", .cwd = "/a/b/", .expected = "/a/"},
         {.path = "../c", .home = "", .cwd = "/a/b/", .expected = "/a/c"},
-        // quoted paths
-        {.path = "'/a/b'", .home = "", .cwd = "", .expected = "/a/b"},
-        {.path = "\"/a/b\"", .home = "", .cwd = "", .expected = "/a/b"},
-        {.path = "'/a/b", .home = "", .cwd = "", .expected = "/'/a/b"},
-        {.path = "\"/a/b", .home = "", .cwd = "", .expected = "/\"/a/b"},
+        // strip surrounding quotes for absolute or home-relative paths
+        {.path = "'/a/b'", .home = "", .cwd = "", .expected = "/a/b"}, // single-quoted abs path: strip
+        {.path = "\"/a/b\"", .home = "", .cwd = "", .expected = "/a/b"}, // double-quoted abs path: strip
+        {.path = "'~/a/b'", .home = "/h", .cwd = "", .expected = "/h/a/b"}, // single-quoted home path: strip
+        {.path = "\"~/a/b\"", .home = "/h", .cwd = "", .expected = "/h/a/b"}, // double-quoted home path: strip
+        {.path = "'a'", .home = "", .cwd = "/c", .expected = "/c/'a'"}, // surrounded with single quotes: keep
+        {.path = "\"a\"", .home = "", .cwd = "/c", .expected = "/c/\"a\""}, // surrounded with double quotes: keep
+        {.path = "'/a/b", .home = "", .cwd = "/c", .expected = "/c/'/a/b"}, // mismatched single quote: keep
+        {.path = "\"/a/b", .home = "", .cwd = "/c", .expected = "/c/\"/a/b"}, // mismatched double quote: keep
     };
     for( auto &tc : tcs ) {
         INFO(tc.path);


### PR DESCRIPTION
## Summary

Go To Folder (Shift+Cmd+G) now accepts paths surrounded by single or double quotes.

Closes #571