### PR TITLE
Fixed two logic issues in the terminal emulator

### DIFF
--- a/Source/Term/source/ShellTask.cpp
+++ b/Source/Term/source/ShellTask.cpp
@@ -551,7 +551,7 @@ void ShellTask::Impl::OnMasterSourceData()
 void ShellTask::Impl::OnCwdSourceData()
 {
     dispatch_assert_background_queue(); // must be called on io_queue
-    const size_t estimated_size = dispatch_source_get_data(master_source);
+    const size_t estimated_size = dispatch_source_get_data(cwd_source);
     Log::Trace("OnCwdSourceData() estimated {} bytes available", estimated_size);
     if( estimated_size == 0 ) {
         // GCD reports dead FDs as zero available data

--- a/Source/Term/source/ShellTask.cpp
+++ b/Source/Term/source/ShellTask.cpp
@@ -640,6 +640,7 @@ void ShellTask::Impl::ProcessPwdPrompt(const void *_d, int _sz)
 
 void ShellTask::Impl::DoOnPwdPromptCallout(std::string_view _cwd, bool _changed) const
 {
+    Log::Trace("shell PID={} current working directory: '{}', changed={}", shell_pid.load(), _cwd, _changed);
     callback_lock.lock();
     auto on_pwd = on_pwd_prompt;
     callback_lock.unlock();
@@ -749,6 +750,7 @@ void ShellTask::Impl::DoCleanUp()
 void ShellTask::Impl::OnShellDied()
 {
     dispatch_assert_background_queue();
+    Log::Info("shell has died, pid={}", shell_pid.load());
 
     // no need to call it if PID is already set to invalid - we're in closing state
     if( shell_pid <= 0 )

--- a/Source/Term/source/ShellTask.cpp
+++ b/Source/Term/source/ShellTask.cpp
@@ -491,15 +491,52 @@ bool ShellTask::Launch(const std::filesystem::path &_work_dir)
 
         if( I->shell_type != ShellType::TCSH ) {
             // setup piping for CWD prompt
-            // using FDs g_PromptPipe/g_SemaphorePipe becuse bash is closing fds [3,20) upon
+            // using FDs g_PromptPipe/g_SemaphorePipe because Bash is closing fds [3,20) upon
             // opening in logon mode (our case)
-            const int cwd_dup_rc = dup2(I->cwd_pipe[1], g_PromptPipe);
-            if( cwd_dup_rc != g_PromptPipe )
-                exit(-1);
 
-            const int semaphore_dup_rc = dup2(I->semaphore_pipe[0], g_SemaphorePipe);
-            if( semaphore_dup_rc != g_SemaphorePipe )
-                exit(-1);
+            // This remapping has to be done "atomically" respecting that FDs can clobber each other
+            if( I->cwd_pipe[1] != g_PromptPipe &&       //
+                I->cwd_pipe[1] != g_SemaphorePipe &&    //
+                I->semaphore_pipe[0] != g_PromptPipe && //
+                I->semaphore_pipe[0] != g_SemaphorePipe ) {
+                // Common/sane case: both FDs are different from each other and from the target ones, just dup2 them
+                if( dup2(I->cwd_pipe[1], g_PromptPipe) != g_PromptPipe )
+                    exit(-1);
+
+                if( dup2(I->semaphore_pipe[0], g_SemaphorePipe) != g_SemaphorePipe )
+                    exit(-1);
+            }
+            else if( I->cwd_pipe[1] == g_PromptPipe ) {
+                // Lucky case: the cwd_pipe write end is already at the target fd, just need to dup2 the semaphore_pipe
+                if( dup2(I->semaphore_pipe[0], g_SemaphorePipe) != g_SemaphorePipe ) // safe if equal
+                    exit(-1);
+            }
+            else if( I->semaphore_pipe[0] == g_SemaphorePipe ) {
+                // Lucky case: the semaphore_pipe read end is already at the target fd, just need to dup2 the cwd_pipe
+                if( dup2(I->cwd_pipe[1], g_PromptPipe) != g_PromptPipe ) // safe if equal
+                    exit(-1);
+            }
+            else if( I->cwd_pipe[1] == g_SemaphorePipe ) {
+                // Unlucky case: the cwd_pipe write end is at the other target fd, need to move it somewhere else first
+                const int tmp_cwd_pipe_fd = dup(I->cwd_pipe[1]);
+                if( tmp_cwd_pipe_fd < 0 )
+                    exit(-1);
+                if( dup2(I->semaphore_pipe[0], g_SemaphorePipe) != g_SemaphorePipe )
+                    exit(-1);
+                if( dup2(tmp_cwd_pipe_fd, g_PromptPipe) != g_PromptPipe )
+                    exit(-1);
+            }
+            else /* if( I->semaphore_pipe[0] == g_PromptPipe  ) */ {
+                // Unlucky case: the semaphore_pipe read end is at the other target fd, need to move it somewhere else
+                // first
+                const int tmp_semaphore_pipe_fd = dup(I->semaphore_pipe[0]);
+                if( tmp_semaphore_pipe_fd < 0 )
+                    exit(-1);
+                if( dup2(I->cwd_pipe[1], g_PromptPipe) != g_PromptPipe )
+                    exit(-1);
+                if( dup2(tmp_semaphore_pipe_fd, g_SemaphorePipe) != g_SemaphorePipe )
+                    exit(-1);
+            }
         }
 
         if( I->shell_type == ShellType::Bash ) {

--- a/Source/Term/tests/ShellTask_IT.cpp
+++ b/Source/Term/tests/ShellTask_IT.cpp
@@ -711,6 +711,7 @@ TEST_CASE(PREFIX "Test multiple shells in parallel via output")
 
     SECTION("bash")
     {
+        INFO("Running a bash shell");
         for( auto &ctx : shells ) {
             ctx.shell.SetShellPath("/bin/bash");
             ctx.shell.SetEnvVar("PS1", ">");
@@ -720,6 +721,7 @@ TEST_CASE(PREFIX "Test multiple shells in parallel via output")
     }
     SECTION("zsh")
     {
+        INFO("Running a zsh shell");
         for( auto &ctx : shells ) {
             ctx.shell.SetShellPath("/bin/zsh");
             ctx.shell.SetEnvVar("PS1", ">");
@@ -729,12 +731,14 @@ TEST_CASE(PREFIX "Test multiple shells in parallel via output")
     }
     SECTION("csh")
     {
+        INFO("Running a csh shell");
         for( auto &ctx : shells ) {
             ctx.shell.SetShellPath("/bin/csh");
         }
     }
     SECTION("tcsh")
     {
+        INFO("Running a tcsh shell");
         for( auto &ctx : shells ) {
             ctx.shell.SetShellPath("/bin/tcsh");
         }

--- a/Source/Term/tests/ShellTask_IT.cpp
+++ b/Source/Term/tests/ShellTask_IT.cpp
@@ -687,9 +687,7 @@ TEST_CASE(PREFIX "Test vim interaction via output")
 }
 
 // this is a torture test to verify assumptions about synchronization under load.
-// unfortunately, this test case works fine on my laptop, but fails on GitHub Actions.
-// after already spending several evenings on this, I'm giving up for now...
-TEST_CASE(PREFIX "Test multiple shells in parallel via output", "[!mayfail]")
+TEST_CASE(PREFIX "Test multiple shells in parallel via output")
 {
     const TempTestDir dir;
     constexpr size_t number = 10; // just casually spawn 10 shells, not a big deal...

--- a/Source/Term/tests/ShellTask_IT.cpp
+++ b/Source/Term/tests/ShellTask_IT.cpp
@@ -38,6 +38,8 @@ using namespace std::chrono_literals;
     return _input;
 }
 
+#if 0
+
 static bool WaitChildrenListToBecome(const ShellTask &_shell,
                                      const std::vector<std::string> &_expected,
                                      std::chrono::nanoseconds _deadline,
@@ -689,6 +691,8 @@ TEST_CASE(PREFIX "Test vim interaction via output")
     REQUIRE(buffer_dump.wait_to_become_with_runloop(5s, 1ms, expected3));
 }
 
+#endif
+
 // this is a torture test to verify assumptions about synchronization under load.
 TEST_CASE(PREFIX "Test multiple shells in parallel via output")
 {
@@ -789,6 +793,7 @@ TEST_CASE(PREFIX "Test multiple shells in parallel via output")
         REQUIRE(ctx.shell_state.wait_to_become(5s, TaskState::Inactive));
 }
 
+#if 0
 TEST_CASE(PREFIX "doesn't keep external cwd change commands in history")
 {
     AtomicHolder<std::string> buffer_dump;
@@ -1047,3 +1052,4 @@ TEST_CASE(PREFIX "ChDir respects literal square-bracketed directory despite glob
     REQUIRE(cwd.wait_to_become(5s, {bracketedDir, true}));
     CHECK(shell.CWD() == bracketedDir.generic_string());
 }
+#endif

--- a/Source/Term/tests/ShellTask_IT.cpp
+++ b/Source/Term/tests/ShellTask_IT.cpp
@@ -767,7 +767,9 @@ TEST_CASE(PREFIX "Test multiple shells in parallel via output")
                                      "                    "
                                      "                    "
                                      "                    ";
-        REQUIRE(shells[i].buffer_dump.wait_to_become(5s, expected));
+        if( const bool arrived = shells[i].buffer_dump.wait_to_become(5s, expected); !arrived ) {
+            FAIL(fmt::format("Shell {} didn't arrive in time, current state: {}", i, shells[i].buffer_dump.value));
+        }
     }
 
     // write the shell number to each shell
@@ -785,7 +787,9 @@ TEST_CASE(PREFIX "Test multiple shells in parallel via output")
                                             "                    "
                                             "                    "
                                             "                    ";
-        REQUIRE(shells[i].buffer_dump.wait_to_become(5s, expected));
+        if( const bool arrived = shells[i].buffer_dump.wait_to_become(5s, expected); !arrived ) {
+            FAIL(fmt::format("Shell {} didn't arrive in time, current state: {}", i, shells[i].buffer_dump.value));
+        }
     }
 
     // now tell all the shell to bugger off

--- a/Source/Term/tests/ShellTask_IT.cpp
+++ b/Source/Term/tests/ShellTask_IT.cpp
@@ -238,6 +238,7 @@ TEST_CASE(PREFIX "Launch=>Exit via output (Bash)")
         shell.SetShellPath("/bin/bash");
         shell.SetEnvVar("PS1", "Hello=>");
         shell.AddCustomShellArgument("bash");
+        shell.AddCustomShellArgument("--norc");
     }
     SECTION("zsh")
     {
@@ -309,6 +310,7 @@ TEST_CASE(PREFIX "ChDir(), verify via output and cwd prompt (Bash)")
         shell.SetShellPath("/bin/bash");
         shell.SetEnvVar("PS1", ">");
         shell.AddCustomShellArgument("bash");
+        shell.AddCustomShellArgument("--norc");
     }
     SECTION("zsh")
     {
@@ -615,6 +617,7 @@ TEST_CASE(PREFIX "Test vim interaction via output")
         shell.SetShellPath("/bin/bash");
         shell.SetEnvVar("PS1", ">");
         shell.AddCustomShellArgument("bash");
+        shell.AddCustomShellArgument("--norc");
     }
     SECTION("zsh")
     {
@@ -708,6 +711,7 @@ TEST_CASE(PREFIX "Test multiple shells in parallel via output")
             ctx.shell.SetShellPath("/bin/bash");
             ctx.shell.SetEnvVar("PS1", ">");
             ctx.shell.AddCustomShellArgument("bash");
+            ctx.shell.AddCustomShellArgument("--norc");
         }
     }
     SECTION("zsh")
@@ -799,6 +803,7 @@ TEST_CASE(PREFIX "doesn't keep external cwd change commands in history")
         shell.SetShellPath("/bin/bash");
         shell.SetEnvVar("PS1", ">");
         shell.AddCustomShellArgument("bash");
+        shell.AddCustomShellArgument("--norc");
     }
     SECTION("zsh")
     {

--- a/Source/Term/tests/ShellTask_IT.cpp
+++ b/Source/Term/tests/ShellTask_IT.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2014-2025 Michael Kazakov. Subject to GNU General Public License version 3.
+// Copyright (C) 2014-2026 Michael Kazakov. Subject to GNU General Public License version 3.
 
 #include "Tests.h"
 #include "AtomicHolder.h"
@@ -37,8 +37,6 @@ using namespace std::chrono_literals;
         _input.append(_to - _input.size(), _with);
     return _input;
 }
-
-#if 0
 
 static bool WaitChildrenListToBecome(const ShellTask &_shell,
                                      const std::vector<std::string> &_expected,
@@ -691,8 +689,6 @@ TEST_CASE(PREFIX "Test vim interaction via output")
     REQUIRE(buffer_dump.wait_to_become_with_runloop(5s, 1ms, expected3));
 }
 
-#endif
-
 // this is a torture test to verify assumptions about synchronization under load.
 TEST_CASE(PREFIX "Test multiple shells in parallel via output")
 {
@@ -801,7 +797,6 @@ TEST_CASE(PREFIX "Test multiple shells in parallel via output")
         REQUIRE(ctx.shell_state.wait_to_become(5s, TaskState::Inactive));
 }
 
-#if 0
 TEST_CASE(PREFIX "doesn't keep external cwd change commands in history")
 {
     AtomicHolder<std::string> buffer_dump;
@@ -1060,4 +1055,3 @@ TEST_CASE(PREFIX "ChDir respects literal square-bracketed directory despite glob
     REQUIRE(cwd.wait_to_become(5s, {bracketedDir, true}));
     CHECK(shell.CWD() == bracketedDir.generic_string());
 }
-#endif

--- a/Source/Term/tests/Tests.cpp
+++ b/Source/Term/tests/Tests.cpp
@@ -20,7 +20,7 @@ static auto g_TestDirPrefix = "_nc__term__test_";
 
 static void DumpLog()
 {
-    std::cout << "Last log entries, up to 100:" << '\n';
+    std::cout << "Last log entries, up to 1000:" << '\n';
     for( auto &line : g_LogSink->last_formatted(1000) )
         std::cout << line;
     std::cout << '\n';


### PR DESCRIPTION
- Under very specific circumstances, the forked child process was not able to correctly set up the communication file descriptors.
- It was possible that the running shell was wrongly pronounced dead.