### PR TITLE
Make ChildrenTracker more accurate

### DIFF
--- a/Source/NimbleCommander/NimbleCommander/States/Terminal/ShellState.mm
+++ b/Source/NimbleCommander/NimbleCommander/States/Terminal/ShellState.mm
@@ -413,7 +413,7 @@ static const auto g_CustomPath = "terminal.customShellPath";
         }
         else {
             __weak NCTermShellState *weakself = self;
-            auto cb = [weakself] {
+            auto cb = [weakself](ChildrenTracker::Event) {
                 dispatch_to_main_queue([weakself] {
                     if( auto strongself = weakself )
                         [strongself updateTitle];

--- a/Source/Term/include/Term/ChildrenTracker.h
+++ b/Source/Term/include/Term/ChildrenTracker.h
@@ -1,33 +1,56 @@
-// Copyright (C) 2023 Michael Kazakov. Subject to GNU General Public License version 3.
+// Copyright (C) 2023-2026 Michael Kazakov. Subject to GNU General Public License version 3.
 #pragma once
 #include <stdint.h>
 #include <compare>
 #include <functional>
 #include <vector>
+#include <iosfwd>
 #include <dispatch/dispatch.h>
 
 namespace nc::term {
 
 // A callback will triggered in a background queue whenever a process with _root_pid or any of its children either fork
-// or exec or exit.
+// or exec or exit. If multiple events happens close to each other they might be coalesced into a single callback with
+// the total amount of events of each type happened since last callback.
 class ChildrenTracker
 {
 public:
-    ChildrenTracker(int _root_pid, std::function<void()> _cb);
+    struct Event {
+        // How many fork events happened
+        unsigned forks = 0;
+
+        // How many exec events happened
+        unsigned execs = 0;
+
+        // How many exit events happened
+        unsigned exits = 0;
+
+        auto operator<=>(const Event &) const noexcept = default;
+    };
+
+    ChildrenTracker(int _root_pid, std::function<void(Event _event)> _cb);
     ChildrenTracker(const ChildrenTracker &) = delete;
     ~ChildrenTracker();
     ChildrenTracker &operator=(const ChildrenTracker &) = delete;
 
+    // Returns the root PID for which this tracker is tracking the children.
     [[nodiscard]] int pid() const;
 
 private:
+    struct ProcessInfo {
+        pid_t pid = -1;
+        uint32_t status = 0; // SIDL | SRUN | SSLEEP | SSTOP | SZOMB
+    };
+
     void Drain();
     int m_RootPID = -1;
     int m_KQ = -1;
     dispatch_queue_t m_Queue = nullptr;
     dispatch_source_t m_Source = nullptr;
-    std::function<void()> m_Callback;
-    std::vector<pid_t> m_Tracked;
+    std::function<void(Event _event)> m_Callback;
+    std::vector<ProcessInfo> m_Tracked;
 };
+
+std::ostream &operator<<(std::ostream &_os, const ChildrenTracker::Event &_event);
 
 } // namespace nc::term

--- a/Source/Term/include/Term/ChildrenTracker.h
+++ b/Source/Term/include/Term/ChildrenTracker.h
@@ -36,6 +36,11 @@ public:
     // Returns the root PID for which this tracker is tracking the children.
     [[nodiscard]] int pid() const;
 
+    // Returns the number of process the tracker is currently aware of, in various states.
+    // This number might be larger than the number of processes currently actively tracked,
+    // since it includes the zombies tracker aware of.
+    [[nodiscard]] size_t KnownProcesses() const;
+
 private:
     struct ProcessInfo {
         pid_t pid = -1;

--- a/Source/Term/source/ChildrenTracker.cpp
+++ b/Source/Term/source/ChildrenTracker.cpp
@@ -136,7 +136,7 @@ void ChildrenTracker::Drain()
         Log::Trace("ChildrenTracker: Received event for PID={} with filter={} and flags={:#x}",
                    event.ident,
                    event.filter,
-                   event.flags);
+                   event.fflags);
         if( event.filter != EVFILT_PROC || (event.flags & EV_ERROR) == EV_ERROR ) {
             continue;
         }
@@ -231,6 +231,11 @@ void ChildrenTracker::Drain()
 int ChildrenTracker::pid() const
 {
     return m_RootPID;
+}
+
+size_t ChildrenTracker::KnownProcesses() const
+{
+    return m_Tracked.size();
 }
 
 std::ostream &operator<<(std::ostream &_os, const ChildrenTracker::Event &_event)

--- a/Source/Term/source/ChildrenTracker.cpp
+++ b/Source/Term/source/ChildrenTracker.cpp
@@ -1,9 +1,11 @@
-// Copyright (C) 2023-2024 Michael Kazakov. Subject to GNU General Public License version 3.
+// Copyright (C) 2023-2026 Michael Kazakov. Subject to GNU General Public License version 3.
 #include "ChildrenTracker.h"
 #include <Base/dispatch_cpp.h>
 #include <algorithm>
 #include <array>
 #include <libproc.h>
+#include <sys/proc.h>
+#include <sys/proc_info.h>
 #include <memory_resource>
 #include <span>
 #include <vector>
@@ -40,11 +42,12 @@ static void Subscribe(const int _kq, const std::span<const pid_t> _pids)
     kevent(_kq, chg.data(), static_cast<int>(chg.size()), nullptr, 0, nullptr);
 }
 
-static void Subscribe(const int _kq, const int _pid) noexcept
+static bool Subscribe(const int _kq, const int _pid) noexcept
 {
     struct kevent change;
     EV_SET(&change, _pid, EVFILT_PROC, EV_ADD | EV_RECEIPT, g_Notes, 0, nullptr);
-    kevent(_kq, &change, 1, nullptr, 0, nullptr);
+    const int res = kevent(_kq, &change, 1, nullptr, 0, nullptr);
+    return res != -1;
 }
 
 static void Unsubscribe(const int _kq, const int _pid) noexcept
@@ -92,14 +95,22 @@ void ChildrenTracker::Drain()
         }
         const pid_t pid = static_cast<pid_t>(event.ident);
         if( event.fflags & NOTE_FORK ) {
-            ++meaningful;
             pid_t pids[4096];
             const int npids = proc_listchildpids(pid, pids, std::size(pids) * sizeof(pid_t));
             for( const pid_t child : std::span{pids, static_cast<size_t>(std::max(npids, 0))} ) {
                 auto it = std::ranges::lower_bound(m_Tracked, child);
                 if( it == m_Tracked.end() || *it != child ) {
-                    Subscribe(m_KQ, child);
-                    m_Tracked.insert(it, child);
+                    // Check the process status before subscribing to its events, it might be a zombie
+                    struct proc_bsdshortinfo bsd_info;
+                    const int pidinfo_ret = proc_pidinfo(child, PROC_PIDT_SHORTBSDINFO, 0, &bsd_info, sizeof(bsd_info));
+                    if( pidinfo_ret != sizeof(bsd_info) || bsd_info.pbsi_status == SZOMB ) {
+                        continue; // no zombies allowed
+                    }
+
+                    if( Subscribe(m_KQ, child) ) {
+                        ++meaningful;
+                        m_Tracked.insert(it, child);
+                    }
                 }
             }
         }

--- a/Source/Term/source/ChildrenTracker.cpp
+++ b/Source/Term/source/ChildrenTracker.cpp
@@ -77,7 +77,7 @@ ChildrenTracker::ChildrenTracker(int _root_pid, std::function<void(Event _event)
             continue; // failed to subscribe, some other issue => skip
         }
 
-        m_Tracked.push_back({.pid = pid, .status = bsd_info.pbsi_status /*, .tracked = true*/});
+        m_Tracked.push_back({.pid = pid, .status = bsd_info.pbsi_status});
     }
 
     m_Queue = dispatch_queue_create("nc::term::ChildrenTracker event queue", DISPATCH_QUEUE_SERIAL);

--- a/Source/Term/source/ChildrenTracker.cpp
+++ b/Source/Term/source/ChildrenTracker.cpp
@@ -1,5 +1,6 @@
 // Copyright (C) 2023-2026 Michael Kazakov. Subject to GNU General Public License version 3.
 #include "ChildrenTracker.h"
+#include "Log.h"
 #include <Base/dispatch_cpp.h>
 #include <algorithm>
 #include <array>
@@ -13,6 +14,8 @@
 #include <thread>
 #include <ranges>
 #include <fmt/format.h>
+#include <fmt/ranges.h>
+#include <fmt/ostream.h>
 #include <signal.h>
 
 namespace nc::term {
@@ -102,6 +105,8 @@ ChildrenTracker::~ChildrenTracker()
 
 void ChildrenTracker::Drain()
 {
+    Log::Debug("ChildrenTracker::Drain() called");
+
     // Use this opportunity to clean up the zombies that were already reaped
     std::erase_if(m_Tracked, [](ProcessInfo &_process) {
         if( _process.status == SZOMB ) {
@@ -109,10 +114,16 @@ void ChildrenTracker::Drain()
             struct proc_bsdshortinfo bsd_info;
             const int pidinfo_ret = proc_pidinfo(_process.pid, PROC_PIDT_SHORTBSDINFO, 0, &bsd_info, sizeof(bsd_info));
             if( pidinfo_ret != sizeof(bsd_info) ) {
+                Log::Trace("ChildrenTracker: Process with PID {} was reaped", _process.pid);
                 return true; // already reaped, just remove it
             }
             // The process with this PID is now longer a zombie => we have an ABA here
-            return bsd_info.pbsi_status != SZOMB;
+            const bool pid_reused = bsd_info.pbsi_status != SZOMB;
+            if( pid_reused ) {
+                Log::Trace("ChildrenTracker: Process with PID {} was reaped and PID was reused for a new process",
+                           _process.pid);
+            }
+            return pid_reused;
         }
         return false;
     });
@@ -122,6 +133,10 @@ void ChildrenTracker::Drain()
     Event callback_event;
     const std::span<const struct kevent> events_span{events, static_cast<size_t>(std::max(nevents, 0))};
     for( const struct kevent &event : events_span ) {
+        Log::Trace("ChildrenTracker: Received event for PID={} with filter={} and flags={:#x}",
+                   event.ident,
+                   event.filter,
+                   event.flags);
         if( event.filter != EVFILT_PROC || (event.flags & EV_ERROR) == EV_ERROR ) {
             continue;
         }
@@ -130,7 +145,9 @@ void ChildrenTracker::Drain()
 
             pid_t pids[4096];
             const int npids = proc_listchildpids(pid, pids, std::size(pids) * sizeof(pid_t));
-            for( const pid_t child : std::span{pids, static_cast<size_t>(std::max(npids, 0))} ) {
+            const std::span<const pid_t> pids_span{pids, static_cast<size_t>(std::max(npids, 0))};
+            Log::Trace("ChildrenTracker: Process with PID {} forked, current child PIDs: {}", pid, pids_span);
+            for( const pid_t child : pids_span ) {
                 auto it = std::ranges::lower_bound(m_Tracked, child, {}, &ProcessInfo::pid);
                 if( it == m_Tracked.end() || it->pid != child ) {
                     // We haven't seen this process before, let's take a closer look at it...
@@ -139,6 +156,7 @@ void ChildrenTracker::Drain()
                     struct proc_bsdshortinfo bsd_info;
                     const int pidinfo_ret = proc_pidinfo(child, PROC_PIDT_SHORTBSDINFO, 0, &bsd_info, sizeof(bsd_info));
                     if( pidinfo_ret != sizeof(bsd_info) ) {
+                        Log::Info("ChildrenTracker: unable to get info for child process with PID {}", child);
                         continue; // process might have died and reaped since we got the pid, skip it
                     }
 
@@ -146,6 +164,7 @@ void ChildrenTracker::Drain()
                         // The child process is already a zombie, make a mark for ourselves, but don't subscribe to it
                         // (no events won't come anyway). Since it's the first time the process appeared, and it's
                         // already a zombie, issue a fork + exit event for it.
+                        Log::Trace("ChildrenTracker: Child process with PID {} is already a zombie", child);
                         ++callback_event.forks;
                         ++callback_event.exits;
                         m_Tracked.insert(it, {.pid = child, .status = SZOMB});
@@ -159,11 +178,15 @@ void ChildrenTracker::Drain()
                         // NB! A TOCTOU remains here - here's a small chance that process
                         // exists AFTER the proc_pidinfo() call and BEFORE the Subscribe() call,
                         // this leads to a situation when NOTE_EXIT will never be delivered.
+                        Log::Trace("ChildrenTracker: Subscribed to child process with PID {}", child);
                         ++callback_event.forks;
                         m_Tracked.insert(it, {.pid = child, .status = bsd_info.pbsi_status});
                     }
                     else {
                         // Failed to subscribe, pronounce it dead and list as a zombie
+                        Log::Info(
+                            "ChildrenTracker: unable to subscribe to child process with PID {}, assuming it's a zombie",
+                            child);
                         ++callback_event.forks;
                         ++callback_event.exits;
                         m_Tracked.insert(it, {.pid = child, .status = SZOMB});
@@ -192,6 +215,7 @@ void ChildrenTracker::Drain()
         // There was a report of a fork yet we didn't manage to register any.
         // This can happen when the child process was already existed and reaped before we got to it.
         // Not much we can do about it, but at least let's invent a synthetic event for this situation.
+        Log::Info("ChildrenTracker: Detected a fork event, but no the new child process, inventing fork+exit");
         ++callback_event.forks;
         ++callback_event.exits;
     }
@@ -199,6 +223,7 @@ void ChildrenTracker::Drain()
     if( callback_event.forks > 0 || //
         callback_event.execs > 0 || //
         callback_event.exits > 0 ) {
+        Log::Trace("ChildrenTracker: Emitting callback with {}", fmt::streamed(callback_event));
         m_Callback(callback_event);
     }
 }

--- a/Source/Term/source/ChildrenTracker.cpp
+++ b/Source/Term/source/ChildrenTracker.cpp
@@ -11,6 +11,7 @@
 #include <span>
 #include <vector>
 #include <thread>
+#include <ranges>
 #include <fmt/format.h>
 #include <signal.h>
 
@@ -119,8 +120,8 @@ void ChildrenTracker::Drain()
     struct kevent events[32];
     const int nevents = kevent(m_KQ, nullptr, 0, events, std::size(events), nullptr);
     Event callback_event;
-
-    for( const struct kevent &event : std::span{events, static_cast<size_t>(std::max(nevents, 0))} ) {
+    const std::span<const struct kevent> events_span{events, static_cast<size_t>(std::max(nevents, 0))};
+    for( const struct kevent &event : events_span ) {
         if( event.filter != EVFILT_PROC || (event.flags & EV_ERROR) == EV_ERROR ) {
             continue;
         }
@@ -182,6 +183,17 @@ void ChildrenTracker::Drain()
                 it->status = SZOMB;
             }
         }
+    }
+
+    if( callback_event.forks == 0 && std::ranges::any_of(events_span, [](const struct kevent &_event) -> bool {
+            return _event.fflags & NOTE_FORK;
+        }) ) {
+        // We're in a bit of pickle here...
+        // There was a report of a fork yet we didn't manage to register any.
+        // This can happen when the child process was already existed and reaped before we got to it.
+        // Not much we can do about it, but at least let's invent a synthetic event for this situation.
+        ++callback_event.forks;
+        ++callback_event.exits;
     }
 
     if( callback_event.forks > 0 || //

--- a/Source/Term/source/ChildrenTracker.cpp
+++ b/Source/Term/source/ChildrenTracker.cpp
@@ -38,7 +38,8 @@ static std::vector<pid_t> InitialPIDs(pid_t _root_pid)
 
 static bool Subscribe(const int _kq, const int _pid) noexcept
 {
-    struct kevent change, result{};
+    struct kevent change = {};
+    struct kevent result = {};
     EV_SET(&change, _pid, EVFILT_PROC, EV_ADD | EV_RECEIPT, g_Notes, 0, nullptr);
     const int res = kevent(_kq, &change, 1, &result, 1, nullptr);
     if( res < 0 )

--- a/Source/Term/source/ChildrenTracker.cpp
+++ b/Source/Term/source/ChildrenTracker.cpp
@@ -6,9 +6,13 @@
 #include <libproc.h>
 #include <sys/proc.h>
 #include <sys/proc_info.h>
+#include <iostream>
 #include <memory_resource>
 #include <span>
 #include <vector>
+#include <thread>
+#include <fmt/format.h>
+#include <signal.h>
 
 namespace nc::term {
 
@@ -32,22 +36,15 @@ static std::vector<pid_t> InitialPIDs(pid_t _root_pid)
     }
 }
 
-static void Subscribe(const int _kq, const std::span<const pid_t> _pids)
-{
-    std::array<char, 4096> mem_buffer;
-    std::pmr::monotonic_buffer_resource mem_resource(mem_buffer.data(), mem_buffer.size());
-    std::pmr::vector<struct kevent> chg(_pids.size(), &mem_resource);
-    for( size_t i = 0; i < _pids.size(); ++i )
-        EV_SET(&chg[i], _pids[i], EVFILT_PROC, EV_ADD | EV_RECEIPT, g_Notes, 0, nullptr);
-    kevent(_kq, chg.data(), static_cast<int>(chg.size()), nullptr, 0, nullptr);
-}
-
 static bool Subscribe(const int _kq, const int _pid) noexcept
 {
-    struct kevent change;
+    struct kevent change, result{};
     EV_SET(&change, _pid, EVFILT_PROC, EV_ADD | EV_RECEIPT, g_Notes, 0, nullptr);
-    const int res = kevent(_kq, &change, 1, nullptr, 0, nullptr);
-    return res != -1;
+    const int res = kevent(_kq, &change, 1, &result, 1, nullptr);
+    if( res < 0 )
+        return false;
+    // EV_RECEIPT always sets EV_ERROR; data == 0 means success
+    return result.data == 0;
 }
 
 static void Unsubscribe(const int _kq, const int _pid) noexcept
@@ -57,13 +54,31 @@ static void Unsubscribe(const int _kq, const int _pid) noexcept
     kevent(_kq, &change, 1, nullptr, 0, nullptr);
 }
 
-ChildrenTracker::ChildrenTracker(int _root_pid, std::function<void()> _cb)
+ChildrenTracker::ChildrenTracker(int _root_pid, std::function<void(Event _event)> _cb)
     : m_RootPID(_root_pid), m_Callback(std::move(_cb))
 {
     assert(m_Callback);
-    m_Tracked = InitialPIDs(_root_pid);
+    const std::vector<pid_t> initial_pids = InitialPIDs(_root_pid);
+
     m_KQ = kqueue();
-    Subscribe(m_KQ, m_Tracked);
+
+    for( const pid_t pid : initial_pids ) {
+        struct proc_bsdshortinfo bsd_info;
+        const int pidinfo_ret = proc_pidinfo(pid, PROC_PIDT_SHORTBSDINFO, 0, &bsd_info, sizeof(bsd_info));
+        if( pidinfo_ret != sizeof(bsd_info) ) {
+            continue; // process might have died and reaped since we got the pid, skip it
+        }
+        if( bsd_info.pbsi_status == SZOMB ) {
+            continue; // no zombies allowed
+        }
+
+        if( !Subscribe(m_KQ, pid) ) {
+            continue; // failed to subscribe, some other issue => skip
+        }
+
+        m_Tracked.push_back({.pid = pid, .status = bsd_info.pbsi_status /*, .tracked = true*/});
+    }
+
     m_Queue = dispatch_queue_create("nc::term::ChildrenTracker event queue", DISPATCH_QUEUE_SERIAL);
     m_Source = dispatch_source_create(DISPATCH_SOURCE_TYPE_READ, m_KQ, 0, m_Queue);
     dispatch_source_set_event_handler_f(m_Source, +[](void *_ctx) { static_cast<ChildrenTracker *>(_ctx)->Drain(); });
@@ -85,54 +100,105 @@ ChildrenTracker::~ChildrenTracker()
 
 void ChildrenTracker::Drain()
 {
+    // Use this opportunity to clean up the zombies that were already reaped
+    std::erase_if(m_Tracked, [](ProcessInfo &_process) {
+        if( _process.status == SZOMB ) {
+            // Verify that either the process was reaped or even already recycled (ABA)
+            struct proc_bsdshortinfo bsd_info;
+            const int pidinfo_ret = proc_pidinfo(_process.pid, PROC_PIDT_SHORTBSDINFO, 0, &bsd_info, sizeof(bsd_info));
+            if( pidinfo_ret != sizeof(bsd_info) ) {
+                return true; // already reaped, just remove it
+            }
+            // The process with this PID is now longer a zombie => we have an ABA here
+            return bsd_info.pbsi_status != SZOMB;
+        }
+        return false;
+    });
+
     struct kevent events[32];
     const int nevents = kevent(m_KQ, nullptr, 0, events, std::size(events), nullptr);
+    Event callback_event;
 
-    int meaningful = 0;
     for( const struct kevent &event : std::span{events, static_cast<size_t>(std::max(nevents, 0))} ) {
         if( event.filter != EVFILT_PROC || (event.flags & EV_ERROR) == EV_ERROR ) {
             continue;
         }
         const pid_t pid = static_cast<pid_t>(event.ident);
         if( event.fflags & NOTE_FORK ) {
+
             pid_t pids[4096];
             const int npids = proc_listchildpids(pid, pids, std::size(pids) * sizeof(pid_t));
             for( const pid_t child : std::span{pids, static_cast<size_t>(std::max(npids, 0))} ) {
-                auto it = std::ranges::lower_bound(m_Tracked, child);
-                if( it == m_Tracked.end() || *it != child ) {
+                auto it = std::ranges::lower_bound(m_Tracked, child, {}, &ProcessInfo::pid);
+                if( it == m_Tracked.end() || it->pid != child ) {
+                    // We haven't seen this process before, let's take a closer look at it...
+
                     // Check the process status before subscribing to its events, it might be a zombie
                     struct proc_bsdshortinfo bsd_info;
                     const int pidinfo_ret = proc_pidinfo(child, PROC_PIDT_SHORTBSDINFO, 0, &bsd_info, sizeof(bsd_info));
-                    if( pidinfo_ret != sizeof(bsd_info) || bsd_info.pbsi_status == SZOMB ) {
-                        continue; // no zombies allowed
+                    if( pidinfo_ret != sizeof(bsd_info) ) {
+                        continue; // process might have died and reaped since we got the pid, skip it
                     }
 
-                    if( Subscribe(m_KQ, child) ) {
-                        ++meaningful;
-                        m_Tracked.insert(it, child);
+                    if( bsd_info.pbsi_status == SZOMB ) {
+                        // The child process is already a zombie, make a mark for ourselves, but don't subscribe to it
+                        // (no events won't come anyway). Since it's the first time the process appeared, and it's
+                        // already a zombie, issue a fork + exit event for it.
+                        ++callback_event.forks;
+                        ++callback_event.exits;
+                        m_Tracked.insert(it, {.pid = child, .status = SZOMB});
+                        continue;
+                    }
+
+                    // Now try to subscribe to the events from this process
+                    const bool subscribed = Subscribe(m_KQ, child);
+                    if( subscribed ) {
+                        // All is nice and dandy, supposedly...
+                        // NB! A TOCTOU remains here - here's a small chance that process
+                        // exists AFTER the proc_pidinfo() call and BEFORE the Subscribe() call,
+                        // this leads to a situation when NOTE_EXIT will never be delivered.
+                        ++callback_event.forks;
+                        m_Tracked.insert(it, {.pid = child, .status = bsd_info.pbsi_status});
+                    }
+                    else {
+                        // Failed to subscribe, pronounce it dead and list as a zombie
+                        ++callback_event.forks;
+                        ++callback_event.exits;
+                        m_Tracked.insert(it, {.pid = child, .status = SZOMB});
                     }
                 }
             }
         }
         if( event.fflags & NOTE_EXEC ) {
-            ++meaningful;
+            ++callback_event.execs;
         }
         if( event.fflags & NOTE_EXIT ) {
-            ++meaningful;
+            ++callback_event.exits;
             Unsubscribe(m_KQ, pid);
-            auto it = std::ranges::lower_bound(m_Tracked, pid);
-            if( it != m_Tracked.end() && *it == pid )
-                m_Tracked.erase(it);
+
+            auto it = std::ranges::lower_bound(m_Tracked, pid, {}, &ProcessInfo::pid);
+            if( it != m_Tracked.end() && it->pid == pid ) {
+                it->status = SZOMB;
+            }
         }
     }
 
-    for( int i = 0; i < meaningful; ++i )
-        m_Callback();
+    if( callback_event.forks > 0 || //
+        callback_event.execs > 0 || //
+        callback_event.exits > 0 ) {
+        m_Callback(callback_event);
+    }
 }
 
 int ChildrenTracker::pid() const
 {
     return m_RootPID;
+}
+
+std::ostream &operator<<(std::ostream &_os, const ChildrenTracker::Event &_event)
+{
+    _os << fmt::format("Event{{ forks: {}, execs: {}, exits: {} }}", _event.forks, _event.execs, _event.exits);
+    return _os;
 }
 
 } // namespace nc::term

--- a/Source/Term/tests/AtomicHolder.h
+++ b/Source/Term/tests/AtomicHolder.h
@@ -9,6 +9,11 @@
 #include <CoreFoundation/CoreFoundation.h>
 #include <mutex>
 
+template <typename T>
+concept Streamable = requires(std::ostream &_os, T _value) {
+    { _os << _value } -> std::convertible_to<std::ostream &>;
+};
+
 template <class T>
 struct AtomicHolder {
     AtomicHolder();
@@ -142,9 +147,11 @@ bool QueuedAtomicHolder<T>::wait_to_become_with_runloop(std::chrono::nanoseconds
         CFRunLoopRunInMode(kCFRunLoopDefaultMode, std::chrono::duration<double>(_slice).count(), false);
     } while( deadline > nc::base::machtime() );
 
-    if( _dump_on_fail ) {
-        auto lg = std::lock_guard{m_Mutex};
-        std::cerr << m_Value << std::endl;
+    if constexpr( Streamable<T> ) {
+        if( _dump_on_fail ) {
+            auto lg = std::lock_guard{m_Mutex};
+            std::cerr << m_Value << std::endl;
+        }
     }
     return false;
 }

--- a/Source/Term/tests/ChildrenTracker_UT.cpp
+++ b/Source/Term/tests/ChildrenTracker_UT.cpp
@@ -25,8 +25,15 @@ static int reap(const int pid)
 TEST_CASE(PREFIX "Generic cases")
 {
     const int p1 = getpid();
-    QueuedAtomicHolder<int> ncalled{0};
-    auto cb = [&ncalled, next = 1] mutable { ncalled.store(next++); };
+    QueuedAtomicHolder<ChildrenTracker::Event> ncalled;
+    ncalled.strict(false);
+
+    auto cb = [&ncalled, current = ChildrenTracker::Event{}](ChildrenTracker::Event _event) mutable {
+        current.forks += _event.forks;
+        current.execs += _event.execs;
+        current.exits += _event.exits;
+        ncalled.store(current);
+    };
 
     const ChildrenTracker tracker{p1, cb};
 
@@ -41,8 +48,9 @@ TEST_CASE(PREFIX "Generic cases")
             exit(0);
         }
         CHECK(p2 > 0);
-        CHECK(ncalled.wait_to_become_with_runloop(5s, 1ms, 1)); // p1 fork -> p2
-        CHECK(ncalled.wait_to_become_with_runloop(5s, 1ms, 2)); // p2 exit
+        // p1 fork -> p2
+        // p2 exit
+        CHECK(ncalled.wait_to_become_with_runloop(5s, 1ms, {.forks = 1, .execs = 0, .exits = 1}, true));
         CHECK(reap(p2) == p2);
     }
     SECTION("Two sequent forks")
@@ -53,16 +61,18 @@ TEST_CASE(PREFIX "Generic cases")
             exit(0);
         }
         CHECK(p2 > 0);
-        CHECK(ncalled.wait_to_become_with_runloop(5s, 1ms, 1)); // p1 fork -> p2
-        CHECK(ncalled.wait_to_become_with_runloop(5s, 1ms, 2)); // p2 exit
+        // p1 fork -> p2
+        // p2 exit
+        CHECK(ncalled.wait_to_become_with_runloop(5s, 1ms, {.forks = 1, .execs = 0, .exits = 1}, true));
         const int p3 = fork();
         if( p3 == 0 ) {
             std::this_thread::sleep_for(10ms);
             exit(0);
         }
         CHECK(p3 > 0);
-        CHECK(ncalled.wait_to_become_with_runloop(5s, 1ms, 3)); // p1 fork -> p3
-        CHECK(ncalled.wait_to_become_with_runloop(5s, 1ms, 4)); // p3 exit
+        // p1 fork -> p3
+        // p3 exit
+        CHECK(ncalled.wait_to_become_with_runloop(5s, 1ms, {.forks = 2, .execs = 0, .exits = 2}, true));
         CHECK(reap(p2) == p2);
         CHECK(reap(p3) == p3);
     }
@@ -80,10 +90,11 @@ TEST_CASE(PREFIX "Generic cases")
             exit(0);
         }
         CHECK(p2 > 0);
-        CHECK(ncalled.wait_to_become_with_runloop(5s, 1ms, 1)); // p1 fork -> p2
-        CHECK(ncalled.wait_to_become_with_runloop(5s, 1ms, 2)); // p2 fork -> p3
-        CHECK(ncalled.wait_to_become_with_runloop(5s, 1ms, 3)); // p3 exit
-        CHECK(ncalled.wait_to_become_with_runloop(5s, 1ms, 4)); // p2 exit
+        // p1 fork -> p2
+        // p2 fork -> p3
+        // p3 exit
+        // p2 exit
+        CHECK(ncalled.wait_to_become_with_runloop(5s, 1ms, {.forks = 2, .execs = 0, .exits = 2}, true));
         CHECK(reap(p2) == p2);
     }
     SECTION("Three recursive forks")
@@ -106,12 +117,13 @@ TEST_CASE(PREFIX "Generic cases")
             exit(0);
         }
         CHECK(p2 > 0);
-        CHECK(ncalled.wait_to_become_with_runloop(5s, 1ms, 1)); // p1 fork -> p2
-        CHECK(ncalled.wait_to_become_with_runloop(5s, 1ms, 2)); // p2 fork -> p3
-        CHECK(ncalled.wait_to_become_with_runloop(5s, 1ms, 3)); // p3 fork -> p4
-        CHECK(ncalled.wait_to_become_with_runloop(5s, 1ms, 4)); // p4 exit
-        CHECK(ncalled.wait_to_become_with_runloop(5s, 1ms, 5)); // p3 exit
-        CHECK(ncalled.wait_to_become_with_runloop(5s, 1ms, 6)); // p2 exit
+        // p1 fork -> p2
+        // p2 fork -> p3
+        // p3 fork -> p4
+        // p4 exit
+        // p3 exit
+        // p2 exit
+        CHECK(ncalled.wait_to_become_with_runloop(5s, 1ms, {.forks = 3, .execs = 0, .exits = 3}, true));
         CHECK(reap(p2) == p2);
     }
     SECTION("2 x two recursive forks")
@@ -140,14 +152,15 @@ TEST_CASE(PREFIX "Generic cases")
         }
         CHECK(p2 > 0);
         CHECK(p4 > 0);
-        CHECK(ncalled.wait_to_become_with_runloop(5s, 1ms, 1)); // p1 fork -> p2
-        CHECK(ncalled.wait_to_become_with_runloop(5s, 1ms, 2)); // p1 fork -> p4
-        CHECK(ncalled.wait_to_become_with_runloop(5s, 1ms, 3)); // p2 fork -> p3
-        CHECK(ncalled.wait_to_become_with_runloop(5s, 1ms, 4)); // p4 fork -> p5
-        CHECK(ncalled.wait_to_become_with_runloop(5s, 1ms, 5)); // p3 exit
-        CHECK(ncalled.wait_to_become_with_runloop(5s, 1ms, 6)); // p5 exit
-        CHECK(ncalled.wait_to_become_with_runloop(5s, 1ms, 7)); // p2 exit
-        CHECK(ncalled.wait_to_become_with_runloop(5s, 1ms, 8)); // p4 exit <-- this one fails on GHA
+        // p1 fork -> p2
+        // p1 fork -> p4
+        // p2 fork -> p3
+        // p4 fork -> p5
+        // p3 exit
+        // p5 exit
+        // p2 exit
+        // p4 exit
+        CHECK(ncalled.wait_to_become_with_runloop(5s, 1ms, {.forks = 4, .execs = 0, .exits = 4}, true));
         CHECK(reap(p2) == p2);
         CHECK(reap(p4) == p4);
     }
@@ -160,11 +173,13 @@ TEST_CASE(PREFIX "Generic cases")
             execl("/usr/bin/uptime", "uptime", nullptr);
         }
         CHECK(p2 > 0);
-        CHECK(ncalled.wait_to_become_with_runloop(5s, 1ms, 1)); // p1 fork -> p2
-        CHECK(ncalled.wait_to_become_with_runloop(5s, 1ms, 2)); // p2 exec
-        CHECK(ncalled.wait_to_become_with_runloop(5s, 1ms, 3)); // p2 exit
+        // p1 fork -> p2
+        // p2 exec
+        // p2 exit
+        CHECK(ncalled.wait_to_become_with_runloop(5s, 1ms, {.forks = 1, .execs = 1, .exits = 1}, true));
         CHECK(reap(p2) == p2);
     }
+
     SECTION("Two recursive forks and exec")
     {
         const int p2 = fork();
@@ -180,18 +195,19 @@ TEST_CASE(PREFIX "Generic cases")
             exit(0);
         }
         CHECK(p2 > 0);
-        CHECK(ncalled.wait_to_become_with_runloop(5s, 1ms, 1)); // p1 fork -> p2
-        CHECK(ncalled.wait_to_become_with_runloop(5s, 1ms, 2)); // p2 fork -> p3
-        CHECK(ncalled.wait_to_become_with_runloop(5s, 1ms, 3)); // p3 exec
-        CHECK(ncalled.wait_to_become_with_runloop(5s, 1ms, 4)); // p3 exit
-        CHECK(ncalled.wait_to_become_with_runloop(5s, 1ms, 5)); // p2 exit
+        // p1 fork -> p2
+        // p2 fork -> p3
+        // p3 exec
+        // p3 exit
+        // p2 exit
+        CHECK(ncalled.wait_to_become_with_runloop(5s, 1ms, {.forks = 2, .execs = 1, .exits = 2}, true));
         CHECK(reap(p2) == p2);
     }
 }
 
 TEST_CASE(PREFIX "Invalid input")
 {
-    const ChildrenTracker tracker{std::numeric_limits<int>::max(), [] { FAIL(); }};
+    const ChildrenTracker tracker{std::numeric_limits<int>::max(), [](ChildrenTracker::Event) { FAIL(); }};
     if( fork() == 0 ) {
         std::this_thread::sleep_for(10ms);
         exit(0);

--- a/Source/Term/tests/ChildrenTracker_UT.cpp
+++ b/Source/Term/tests/ChildrenTracker_UT.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 Michael Kazakov. Subject to GNU General Public License version 3.
+// Copyright (C) 2023-2026 Michael Kazakov. Subject to GNU General Public License version 3.
 
 #include "Tests.h"
 #include "AtomicHolder.h"
@@ -13,7 +13,16 @@ using namespace nc;
 using namespace nc::term;
 using namespace std::chrono_literals;
 
-TEST_CASE(PREFIX "Generic cases", "[!mayfail]")
+static int reap(const int pid)
+{
+    pid_t r = 0;
+    do {
+        r = waitpid(pid, nullptr, 0);
+    } while( r == -1 && errno == EINTR );
+    return r;
+}
+
+TEST_CASE(PREFIX "Generic cases")
 {
     const int p1 = getpid();
     QueuedAtomicHolder<int> ncalled{0};
@@ -28,19 +37,19 @@ TEST_CASE(PREFIX "Generic cases", "[!mayfail]")
     {
         const int p2 = fork();
         if( p2 == 0 ) {
-            std::this_thread::sleep_for(1ms);
+            std::this_thread::sleep_for(10ms);
             exit(0);
         }
         CHECK(p2 > 0);
         CHECK(ncalled.wait_to_become_with_runloop(5s, 1ms, 1)); // p1 fork -> p2
         CHECK(ncalled.wait_to_become_with_runloop(5s, 1ms, 2)); // p2 exit
-        CHECK(waitpid(p2, nullptr, 0) == p2);
+        CHECK(reap(p2) == p2);
     }
     SECTION("Two sequent forks")
     {
         const int p2 = fork();
         if( p2 == 0 ) {
-            std::this_thread::sleep_for(1ms);
+            std::this_thread::sleep_for(10ms);
             exit(0);
         }
         CHECK(p2 > 0);
@@ -48,26 +57,26 @@ TEST_CASE(PREFIX "Generic cases", "[!mayfail]")
         CHECK(ncalled.wait_to_become_with_runloop(5s, 1ms, 2)); // p2 exit
         const int p3 = fork();
         if( p3 == 0 ) {
-            std::this_thread::sleep_for(1ms);
+            std::this_thread::sleep_for(10ms);
             exit(0);
         }
         CHECK(p3 > 0);
         CHECK(ncalled.wait_to_become_with_runloop(5s, 1ms, 3)); // p1 fork -> p3
         CHECK(ncalled.wait_to_become_with_runloop(5s, 1ms, 4)); // p3 exit
-        CHECK(waitpid(p2, nullptr, 0) == p2);
-        CHECK(waitpid(p3, nullptr, 0) == p3);
+        CHECK(reap(p2) == p2);
+        CHECK(reap(p3) == p3);
     }
     SECTION("Two recursive forks")
     {
         const int p2 = fork();
         if( p2 == 0 ) {
-            std::this_thread::sleep_for(1ms);
+            std::this_thread::sleep_for(10ms);
             if( const int p3 = fork(); p3 == 0 ) {
-                std::this_thread::sleep_for(1ms);
+                std::this_thread::sleep_for(10ms);
                 exit(0);
             }
             else
-                waitpid(p3, nullptr, 0);
+                reap(p3);
             exit(0);
         }
         CHECK(p2 > 0);
@@ -75,25 +84,25 @@ TEST_CASE(PREFIX "Generic cases", "[!mayfail]")
         CHECK(ncalled.wait_to_become_with_runloop(5s, 1ms, 2)); // p2 fork -> p3
         CHECK(ncalled.wait_to_become_with_runloop(5s, 1ms, 3)); // p3 exit
         CHECK(ncalled.wait_to_become_with_runloop(5s, 1ms, 4)); // p2 exit
-        CHECK(waitpid(p2, nullptr, 0) == p2);
+        CHECK(reap(p2) == p2);
     }
     SECTION("Three recursive forks")
     {
         const int p2 = fork();
         if( p2 == 0 ) {
-            std::this_thread::sleep_for(1ms);
+            std::this_thread::sleep_for(10ms);
             if( const int p3 = fork(); p3 == 0 ) {
-                std::this_thread::sleep_for(1ms);
+                std::this_thread::sleep_for(10ms);
                 if( const int p4 = fork(); p4 == 0 ) {
-                    std::this_thread::sleep_for(1ms);
+                    std::this_thread::sleep_for(10ms);
                     exit(0);
                 }
                 else
-                    waitpid(p4, nullptr, 0);
+                    reap(p4);
                 exit(0);
             }
             else
-                waitpid(p3, nullptr, 0);
+                reap(p3);
             exit(0);
         }
         CHECK(p2 > 0);
@@ -103,30 +112,30 @@ TEST_CASE(PREFIX "Generic cases", "[!mayfail]")
         CHECK(ncalled.wait_to_become_with_runloop(5s, 1ms, 4)); // p4 exit
         CHECK(ncalled.wait_to_become_with_runloop(5s, 1ms, 5)); // p3 exit
         CHECK(ncalled.wait_to_become_with_runloop(5s, 1ms, 6)); // p2 exit
-        CHECK(waitpid(p2, nullptr, 0) == p2);
+        CHECK(reap(p2) == p2);
     }
     SECTION("2 x two recursive forks")
     {
         const int p2 = fork();
         if( p2 == 0 ) {
-            std::this_thread::sleep_for(1ms);
+            std::this_thread::sleep_for(10ms);
             if( const int p3 = fork(); p3 == 0 ) {
-                std::this_thread::sleep_for(1ms);
+                std::this_thread::sleep_for(10ms);
                 exit(0);
             }
             else
-                waitpid(p3, nullptr, 0);
+                reap(p3);
             exit(0);
         }
         const int p4 = fork();
         if( p4 == 0 ) {
-            std::this_thread::sleep_for(1ms);
+            std::this_thread::sleep_for(10ms);
             if( const int p3 = fork(); p3 == 0 ) {
-                std::this_thread::sleep_for(1ms);
+                std::this_thread::sleep_for(10ms);
                 exit(0);
             }
             else
-                waitpid(p3, nullptr, 0);
+                reap(p3);
             exit(0);
         }
         CHECK(p2 > 0);
@@ -139,14 +148,14 @@ TEST_CASE(PREFIX "Generic cases", "[!mayfail]")
         CHECK(ncalled.wait_to_become_with_runloop(5s, 1ms, 6)); // p5 exit
         CHECK(ncalled.wait_to_become_with_runloop(5s, 1ms, 7)); // p2 exit
         CHECK(ncalled.wait_to_become_with_runloop(5s, 1ms, 8)); // p4 exit <-- this one fails on GHA
-        CHECK(waitpid(p2, nullptr, 0) == p2);
-        CHECK(waitpid(p4, nullptr, 0) == p4);
+        CHECK(reap(p2) == p2);
+        CHECK(reap(p4) == p4);
     }
     SECTION("Fork and exec")
     {
         const int p2 = fork();
         if( p2 == 0 ) {
-            std::this_thread::sleep_for(1ms);
+            std::this_thread::sleep_for(10ms);
             close(1);
             execl("/usr/bin/uptime", "uptime", nullptr);
         }
@@ -154,20 +163,20 @@ TEST_CASE(PREFIX "Generic cases", "[!mayfail]")
         CHECK(ncalled.wait_to_become_with_runloop(5s, 1ms, 1)); // p1 fork -> p2
         CHECK(ncalled.wait_to_become_with_runloop(5s, 1ms, 2)); // p2 exec
         CHECK(ncalled.wait_to_become_with_runloop(5s, 1ms, 3)); // p2 exit
-        CHECK(waitpid(p2, nullptr, 0) == p2);
+        CHECK(reap(p2) == p2);
     }
     SECTION("Two recursive forks and exec")
     {
         const int p2 = fork();
         if( p2 == 0 ) {
-            std::this_thread::sleep_for(1ms);
+            std::this_thread::sleep_for(10ms);
             if( const int p3 = fork(); p3 == 0 ) {
-                std::this_thread::sleep_for(1ms);
+                std::this_thread::sleep_for(10ms);
                 close(1);
                 execl("/usr/bin/uptime", "uptime", nullptr);
             }
             else
-                waitpid(p3, nullptr, 0);
+                reap(p3);
             exit(0);
         }
         CHECK(p2 > 0);
@@ -176,7 +185,7 @@ TEST_CASE(PREFIX "Generic cases", "[!mayfail]")
         CHECK(ncalled.wait_to_become_with_runloop(5s, 1ms, 3)); // p3 exec
         CHECK(ncalled.wait_to_become_with_runloop(5s, 1ms, 4)); // p3 exit
         CHECK(ncalled.wait_to_become_with_runloop(5s, 1ms, 5)); // p2 exit
-        CHECK(waitpid(p2, nullptr, 0) == p2);
+        CHECK(reap(p2) == p2);
     }
 }
 
@@ -184,7 +193,7 @@ TEST_CASE(PREFIX "Invalid input")
 {
     const ChildrenTracker tracker{std::numeric_limits<int>::max(), [] { FAIL(); }};
     if( fork() == 0 ) {
-        std::this_thread::sleep_for(1ms);
+        std::this_thread::sleep_for(10ms);
         exit(0);
     }
 }

--- a/Source/Term/tests/ChildrenTracker_UT.cpp
+++ b/Source/Term/tests/ChildrenTracker_UT.cpp
@@ -36,6 +36,7 @@ TEST_CASE(PREFIX "Generic cases")
     };
 
     const ChildrenTracker tracker{p1, cb};
+    CHECK(tracker.KnownProcesses() == 1); // expect only this single process and no children at the beginning
 
     SECTION("Nothing")
     {
@@ -208,9 +209,12 @@ TEST_CASE(PREFIX "Generic cases")
 TEST_CASE(PREFIX "Invalid input")
 {
     const ChildrenTracker tracker{std::numeric_limits<int>::max(), [](ChildrenTracker::Event) { FAIL(); }};
-    if( fork() == 0 ) {
+    if( const int p = fork(); p == 0 ) {
         std::this_thread::sleep_for(10ms);
         exit(0);
+    }
+    else {
+        CHECK(reap(p));
     }
 }
 

--- a/Source/Term/tests/Tests.cpp
+++ b/Source/Term/tests/Tests.cpp
@@ -41,7 +41,7 @@ int main(int argc, char *argv[])
 {
     const nc::base::ExecutionDeadline deadline(nc::base::AmIBeingDebugged() ? std::chrono::hours(1)
                                                                             : std::chrono::minutes(1));
-    g_Log->set_level(spdlog::level::debug);
+    g_Log->set_level(spdlog::level::trace);
     Log::Set(g_Log);
     const int result = Catch::Session().run(argc, argv);
     return result;


### PR DESCRIPTION
Now it tracks zombie children and also reports accumulated statistics per kevent, instead of executing the callback multiple times.